### PR TITLE
Add CallUUID tag parsing

### DIFF
--- a/SIPSMsgParser.py
+++ b/SIPSMsgParser.py
@@ -15,8 +15,14 @@ class SIPSMsgParser(LogParser):
     pattern_sip_msg_sent = re.compile('^(\S+)(?::|) Sending  \[\S+\] \d+ bytes to (\S+) >>>>>$')
     # Call-ID: ...
     pattern_sip_call_id = re.compile('Call-ID: (.+)$', re.IGNORECASE)
- 
-     
+    # SIP-19501 [adjames] - Add pattern to determine SIP request for request and response
+    # CSeq: 3 INVITE
+    pattern_sip_request = re.compile('CSeq: (\d+) (\w+)$')
+    # SIP-19501 [adjames] - Add pattern to read UUID marker from log
+    # 16:28:01.319: CID:UUID>FF896752-F2E8-46A4-95C5-499BF2919C84-1@UTE_HOME:N4J2Q1678T29107HIBVLHE693G000001:
+    # SIP-19501 [adjames] - Create tuple to allow us to determine which requests require UUID matching.
+    call_request_tuple = ("INVITE","ACK","BYE","PRACK","NOTIFY","INFO","REFER")
+    
     def __init__(self,submitter,tags={}):
         logging.debug("SIPSMsgParser __init__")
         LogParser.__init__(self, submitter,tags)
@@ -26,13 +32,16 @@ class SIPSMsgParser(LogParser):
         self.d_sip_msg = {}
         # bool we are in sip msg
         self.in_sip_msg = 0
-
+        # SIP-19501 [adjames] - if set we are waiting for CID:UUID> line match before submitting message.
+        self.in_uuid_match = 0
         
     def init_sip_message(self):
+        if (self.in_uuid_match):
         self.in_sip_msg = 1
         self.sip_msg = ''
         #self.d_sip_msg.clear()
         self.d_sip_msg = self.d_common_tags.copy()
+        self.in_uuid_match = 0
         return
     
     def submit_sip_message(self):
@@ -40,6 +49,7 @@ class SIPSMsgParser(LogParser):
         self.d_sip_msg['message'] = self.sip_msg
         self.submitter.d_submit(self.d_sip_msg,"SIP")        
         self.in_sip_msg = 0
+        self.in_uuid_match = 0
         return
     
     def parse_line(self, line, claimed=False):
@@ -62,9 +72,16 @@ class SIPSMsgParser(LogParser):
                     _re_call_id = self.pattern_sip_call_id.match(line)
                     if(_re_call_id):
                         self.d_sip_msg['call_id'] = (_re_call_id.group(1).rstrip())[:4096]
+                # SIP-19501 [adjames] - Add pattern to determine SIP request for request and response
+                if not 'request' in self.d_sip_msg.keys():
+                    _re_request = self.pattern_sip_request.match(line)
+                    if (_re_request):
+                        self.d_sip_msg['request'] = (_re_request.group(2).rstrip())[:4096]
                 # checking for the end, and sending
                 if(self.match_time_stamp(line)):
-                    self.submit_sip_message()
+                    # SIP-19501 [adjames] - For call based requests, keep parsing until UUID marker (or another sip message)
+                    else:
+                        self.submit_sip_message()
                     return self.parse_line(line)
                 #else:
 
@@ -92,6 +109,11 @@ class SIPSMsgParser(LogParser):
                         self.d_sip_msg['to'] = (self.re_line.group(2))[:4096]
                         self.d_sip_msg['@timestamp'] = datetime(self.cur_date['y'],self.cur_date['m'],self.cur_date['d'],self.cur_time['h'],self.cur_time['m'],self.cur_time['s'],self.cur_time['ms'])
 
+                    # SIP-19501 [adjames] - Look for matching CID:UUID marker to add uuid to this msg and submit. 
+                    elif (self.in_uuid_match):
+                        self.re_line = self.pattern_uuid_marker.search(line)
+                        if (self.re_line):
+                            self.submit_sip_message()    
 #            if(self.pattern_std_msg.match(line)): 
 #                self.submitter.submit(line)
                     

--- a/TLibMsgParser.py
+++ b/TLibMsgParser.py
@@ -40,7 +40,22 @@ class TLibMsgParser(LogParser):
     #     AttributeClientID    1145
     # 2015-08-17T23:16:17.458 Int 04545 Interaction message "EventError" sent to 24 ("ICON_localdb")
     # 2015-08-17T23:16:17.458 Trc 04542 EventError sent to [24] (00000479 ICON_localdb 10.51.60.68:59022)    
- 
+    # SIP-19501 [adjames] - Pattern for UUID attribute
+    pattern_tlib_uuid = re.compile('\tAttributeCallUUID\t\'(\S+)\'$')
+    # SIP-19501 [adjames] - Pattern for ref_id attribute, used to match requests to UUID marker.
+    pattern_tlib_ref_id = re.compile('\tAttributeReferenceID\t(\d+)$')
+    # SIP-19501 [adjames] - Pattern for UUID marker printed after tlib request.
+    pattern_uuid_marker = re.compile('.*RID:CUUID>(.*):(.*):')   
+    # SIP-19501 [adjames] - Create tuple to allow us to determine which messages/requests require UUID matching.
+    call_request_tuple = ("RequestMakeCall", "RequestMakePredictiveCall","RequestRouteCall","RequestApplyTreatment",
+   			  "RequestGiveMusicTreatment","RequestGiveRingBackTreatment","RequestGiveSilenceTreatment",
+   			  "RequestSingleStepConference","RequestCollectDigits","RequestSendDTMF","RequestAnswerCall",
+   			  "RequestHoldCall","RequestRetrieveCall","RequestReconnectCall","RequestMergeCalls",
+			  "RequestSetMuteOn","RequestSetMuteOff","RequestReleaseCall","RequestSingleStepTransfer",
+			  "RequestInitiateTransfer","RequestCompleteTransfer","RequestInitiateConference",
+			  "RequestCompleteConference","RequestDeleteFromConference","RequestMuteTransfer",
+			  "RequestAlternateCall","RequestRedirectCall","RequestListenDisconnect","RequestListenReconnect",
+			  "RequestClearCall")
      
     def __init__(self,submitter,tags={}):
         logging.debug("TLibMsgParser __init__")
@@ -51,13 +66,18 @@ class TLibMsgParser(LogParser):
         self.d_tlib_msg = {}
         # bool we are in sip msg
         self.in_tlib_msg = 0
-
+        # SIP-19501 [adjames] - if set we are waiting for RID:CUUID> line match before submitting message.
+        self.in_uuid_match = 0
         
     def init_tlib_message(self):
+        if (self.in_uuid_match):
+            self.d_tlib_msg['call_uuid'] = "unknown"
+            self.submit_tlib_message()
         self.in_tlib_msg = 1
         self.tlib_msg = ''
         self.d_tlib_msg.clear()
         self.d_tlib_msg = self.d_common_tags.copy()
+        self.in_uuid_match = 0
         return
     
     def submit_tlib_message(self):
@@ -65,6 +85,7 @@ class TLibMsgParser(LogParser):
         self.d_tlib_msg['message'] = self.tlib_msg
         self.submitter.d_submit(self.d_tlib_msg,"TLib")        
         self.in_tlib_msg = 0
+        self.in_uuid_match = 0
         return
     
     def parse_line(self, line, claimed=False):
@@ -98,7 +119,17 @@ class TLibMsgParser(LogParser):
             if not 'ThisDN' in self.d_tlib_msg.keys():
                 _re_this_dn = self.pattern_tlib_this_dn.match(line)
                 if(_re_this_dn):
-                    self.d_tlib_msg['ThisDN'] = _re_this_dn.group(1).rstrip()       
+                    self.d_tlib_msg['ThisDN'] = _re_this_dn.group(1).rstrip()  
+            # SIP-19501 [adjames] - Add uuid to keys.
+            if not 'call_uuid' in self.d_tlib_msg.keys():
+                _re_call_uuid = self.pattern_tlib_uuid.match(line)
+                if (_re_call_uuid):
+                    self.d_tlib_msg['call_uuid'] = _re_call_uuid.group(1).rstrip()
+            # SIP-19501 [adjames] - Store ref_id for request, used to match requests to UUID marker.
+            if not 'RefID' in self.d_tlib_msg.keys():
+	        _re_ref_id = self.pattern_tlib_ref_id.match(line)
+	        if (_re_ref_id):
+            	    self.d_tlib_msg['RefID'] = _re_ref_id.group(1).rstrip()  
             #    # checking for the end, and sending
 
             # in most cases TLib message attributes start with a \t - tab
@@ -106,7 +137,12 @@ class TLibMsgParser(LogParser):
             if(line[0] != '\t'):
                 #and we'll be expecting a timestamp after the TLib message ends
                 if(self.match_time_stamp(line)):
-                    self.submit_tlib_message()
+                    # SIP-19501 [adjames] - For call based requests, keep parsing until UUID marker (or another tlib message)
+                    if ("method" in self.d_tlib_msg and self.d_tlib_msg['method'] in self.call_request_tuple):
+                        self.in_tlib_msg = 0
+                        self.in_uuid_match = 1
+                    else:
+                        self.submit_tlib_message()
                     # another TLib message can begin right here, therefore need to parse this line
                     return self.parse_line(line)
             #    #else:
@@ -135,7 +171,12 @@ class TLibMsgParser(LogParser):
                     self.d_tlib_msg['@timestamp'] = datetime(self.cur_date['y'],self.cur_date['m'],self.cur_date['d'],self.cur_time['h'],self.cur_time['m'],self.cur_time['s'],self.cur_time['ms'])
                     
                     return True
-                    
+                # SIP-19501 [adjames] - Look for matching REFID:CUUID marker to add uuid to this request and submit. 
+                if (self.in_uuid_match):
+                    self.re_line = self.pattern_uuid_marker.search(line)
+                    if (self.re_line and self.re_line.group(1) == self.d_tlib_msg['RefID']):
+                        self.d_tlib_msg['call_uuid'] = self.re_line.group(2)
+                        self.submit_tlib_message()       
         return False
 
     def __del__(self):


### PR DESCRIPTION
SIPServer log will include tags to map CallUUID to SIP messages and TLib
requests (SIP-19501). This code will parse these new tags and add
call_uuid index to all call based messages to allow call tracking
between SIP and TLib.
